### PR TITLE
Create CITATION.cff for DOI and a small bug fix to the hardware interface

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "UKAEA ROS 2 Driver for Comau CRCOpen"
+authors:
+  - family-names: "Slater"
+    given-names: "Adam"
+  - family-names: "Saleem"
+    given-names: "Abdullah"
+version: 1.0.0
+date-released: 2025-10-14
+url: "https://github.com/ukaea/CRCOpenROS2Driver"
+license: "Apache-2.0"
+doi: "10.5281/zenodo.TBD"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,8 +7,8 @@ authors:
     given-names: "Adam"
   - family-names: "Saleem"
     given-names: "Abdullah"
-version: 1.0.0
-date-released: 2025-10-14
+version: 0.5.0
+date-released: 2025-10-17
 url: "https://github.com/ukaea/CRCOpenROS2Driver"
 license: "Apache-2.0"
 doi: "10.5281/zenodo.TBD"

--- a/crcopen_hardware/include/crcopen_hardware.hpp
+++ b/crcopen_hardware/include/crcopen_hardware.hpp
@@ -88,7 +88,7 @@ public:
    * @return SUCCESS if initialized; FAILURE if parameters are missing/invalid; ERROR otherwise.
    * @post UNCONFIGURED state on success.
    */
-  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams & params) override;
 
   /**
    * @brief Export per-joint state interfaces.

--- a/crcopen_hardware/src/crcopen_hardware.cpp
+++ b/crcopen_hardware/src/crcopen_hardware.cpp
@@ -112,10 +112,11 @@ namespace crcopen_hardware
     return;
   }
 
-  hardware_interface::CallbackReturn CRCOpenHardware::on_init(const hardware_interface::HardwareInfo &info)
+  hardware_interface::CallbackReturn CRCOpenHardware::on_init(const hardware_interface::HardwareComponentInterfaceParams & params)
   {
+      
     RCLCPP_INFO(rclcpp::get_logger(LOG_NAME), "on_init");
-    if (hardware_interface::SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS)
+    if (hardware_interface::SystemInterface::on_init(params) != hardware_interface::CallbackReturn::SUCCESS)
     {
       return hardware_interface::CallbackReturn::ERROR;
     }


### PR DESCRIPTION
# Summary

This PR does two things:
* Adds a CITATION.cff file so the CRCOpen ROS2 driver can be cited properly and linked to a DOI once configured in GitHub.
* Fixes a small break in the hardware interface caused by recent ros2_control API changes.

# Details

**CITATION.cff**

* Introduces a CITATION.cff file following GitHub’s recommended format so users can easily generate citations and associate a DOI with this repository.
* This addresses issue #6 (create a DOI for our open source ROS2 driver) and follows the guidance in the GitHub docs on citation files.

**Hardware interface bug fix**

* Updates the hardware interface on_init method to use the new hardware_interface::HardwareComponentInterfaceParams API and passes params through to SystemInterface::on_init.
* This resolves a build break on Rolling caused by the ros2_control / hardware_interface API change, restoring compatibility.

Closes https://github.com/ukaea/CRCOpenROS2Driver/issues/6