### PR TITLE
[Rolling] Replace removed ament_target_dependencies in crcopen_hardware CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode/
+
+.colcon/

--- a/crcopen_hardware/CMakeLists.txt
+++ b/crcopen_hardware/CMakeLists.txt
@@ -32,29 +32,36 @@ add_library(
 )
 target_include_directories(
   ${PROJECT_NAME}
-  PRIVATE
-  include
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
 )
-ament_target_dependencies(
-  ${PROJECT_NAME}
-  rclcpp
-  rclcpp_lifecycle
-  lifecycle_msgs
-  hardware_interface
-  pluginlib
-  ruckig
-  orl_driver
-  )
-target_link_libraries(${PROJECT_NAME}  
-  orl_driver
-  ruckig::ruckig
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    ${rclcpp_TARGETS}
+    ${rclcpp_lifecycle_TARGETS}
+    ${lifecycle_msgs_TARGETS}
+    ${hardware_interface_TARGETS}
+    ${pluginlib_TARGETS}
+    ${ruckig_TARGETS}
+    ${orl_driver_TARGETS}
+)
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    orl_driver
+    ruckig::ruckig
 )
 
 pluginlib_export_plugin_description_file(hardware_interface crcopen_hardware.xml)
 
 install(
   TARGETS ${PROJECT_NAME}
-  DESTINATION lib
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 install(
   DIRECTORY include/
@@ -72,12 +79,7 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_export_include_directories(
-  include
-)
-ament_export_libraries(
-  ${PROJECT_NAME}
-)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   rclcpp
   rclcpp_lifecycle


### PR DESCRIPTION
This updates crcopen_hardware/CMakeLists.txt to use target-based include/link/export settings instead of ament_target_dependencies so the package builds again on ROS 2 Rolling after the API removal.

Terminal Output before
<img width="583" height="313" alt="image" src="https://github.com/user-attachments/assets/b0b0fa46-7a9b-473c-8f04-0c3299dd33c3" />

Terminal Output After
**
<img width="1500" height="294" alt="image" src="https://github.com/user-attachments/assets/243aeafc-7384-46f7-b671-54d3b89c3b9b" />
**